### PR TITLE
Allow null for empty to-one relationships

### DIFF
--- a/src/models/relationship.model.ts
+++ b/src/models/relationship.model.ts
@@ -15,10 +15,12 @@ export default class Relationship {
  public data?: ResourceLinkage;
  public meta?: Meta;
  public constructor(options: RelationshipOptions) {
+  // data can be explicitly set to null for empty to-one relationships
+  if (typeof options.data !== "undefined") this.data = options.data;
+
   if (options.links) this.links = options.links;
-  if (options.data) this.data = options.data;
   if (options.meta) this.meta = options.meta;
-  if (!this.links && !this.data && !this.meta) {
+  if (typeof options.data === "undefined" && !this.links && !this.meta) {
    throw new Error(
     "Relationships must contain at least a link, data, or meta. See https://jsonapi.org/format/#document-resource-object-relationships for more information."
    );

--- a/src/utils/serializer.utils.ts
+++ b/src/utils/serializer.utils.ts
@@ -20,11 +20,13 @@ export async function recurseRelators(
     const newRelators = relator.getRelatedRelators();
     await Promise.all(
      relatedData.flat().map(async (datum) => {
-      const resource = await relator.getRelatedResource(datum);
-      const key = resource.getKey();
-      if (!keys.includes(key)) {
-       included.push(resource);
-       keys.push(key);
+      if (datum !== null) {
+       const resource = await relator.getRelatedResource(datum);
+       const key = resource.getKey();
+       if (!keys.includes(key)) {
+        included.push(resource);
+        keys.push(key);
+       }
       }
      })
     );

--- a/test/serializer.test.ts
+++ b/test/serializer.test.ts
@@ -24,6 +24,7 @@ const NUMBER_OF_TESTS = 2;
 
 const ArticleSerializer = new Serializer("articles");
 const CommentSerializer = new Serializer<Comment>("comments");
+const NullSerializer = new Serializer("null");
 
 const ArticleCommentRelator = new Relator(
  async (article: Article) => article.getComments(),
@@ -33,8 +34,13 @@ const CommentArticleRelator = new Relator(
  async (article: Comment) => article.getArticle(),
  ArticleSerializer
 );
+const ArticleNullRelator = new Relator(
+ async (article: Article) => Promise.resolve(null),
+ NullSerializer
+);
 
 ArticleSerializer.setRelators(ArticleCommentRelator);
+ArticleSerializer.setRelators(ArticleNullRelator);
 CommentSerializer.setRelators(CommentArticleRelator);
 
 const UserArticleRelationshipLinker = new Linker((user, articles) =>


### PR DESCRIPTION
# Description

Update to allow `null` for empty to-one relationships as defined in the JSON:API spec: https://jsonapi.org/format/#document-resource-object-related-resource-links

```
Resource linkage MUST be represented as one of the following:

* null for empty to-one relationships.
* an empty array ([]) for empty to-many relationships.
* a single resource identifier object for non-empty to-one relationships.
& an array of resource identifier objects for non-empty to-many relationships.
```

# Details
In order to support this, changes needed to be applied to two modules:
* `models/relationship.model` - Where the Relationship class was checking for truthiness of data where it should have been checking if the data was defined.
* `utils/serializer.utils` - Where the `recurseRelators` method assumed that related data could always be converted into a Resource.

# Notes
One thing I find interesting, is that the `fetch` method used in `Relator` was typed to support resolving with `null`, which meant that this error was getting thrown at runtime rather than at compile time. This leads me to believe that the intent was for `null` to be supported and that the behavior encountered when actually returning `null` is a bug.

Anyways, happy to make any requested changes.