### PR TITLE
Add assertions to issue-23 test (testing depth > 1)

### DIFF
--- a/.changeset/new-guests-serve.md
+++ b/.changeset/new-guests-serve.md
@@ -1,0 +1,5 @@
+---
+"ts-japi": patch
+---
+
+Adds assertions to issue-23 test (testing depth > 1)

--- a/test/issue-23.test.ts
+++ b/test/issue-23.test.ts
@@ -7,37 +7,29 @@ describe("Serializer", () => {
   type B = { id: string; prop: string };
   type C = { id: string; prop: string };
 
-  const counters = { AtoB: 0, BtoC: 0 };
-
   const SerializerC = new Serializer<C>("c");
 
   const BtoCRelator = new Relator<B, C>(async (data) => {
-   counters.BtoC++;
    return { id: "1", prop: "c" };
   }, SerializerC);
 
   const SerializerB = new Serializer<B>("b", {
-   relators: { c: BtoCRelator },
+   relators: { c: BtoCRelator }
   });
 
   const AtoBRelator = new Relator<A, B>(async (data) => {
-   counters.AtoB++;
    return { id: "1", prop: "b" };
   }, SerializerB);
 
   const SerializerA = new Serializer<A>("a", {
-   relators: { b: AtoBRelator },
+   relators: { b: AtoBRelator }
   });
 
   const serialized = await SerializerA.serialize({ id: "1", prop: "a" }, { depth: 2 });
 
-  console.log(
-   `A to B: ${counters.AtoB}\nB to C: ${counters.BtoC}\nSerialized Data:\n${inspect(
-    serialized,
-    false,
-    20
-   )}`
-  );
-  counters.AtoB = counters.BtoC = 0;
+  expect(serialized.included).toHaveLength(2);
+  expect(serialized.included.find((data) => data.type === "b")).toBeDefined();
+  expect(serialized.included.find((data) => data.type === "c")).toBeDefined();
+  // console.log(inspect(serialized, false, 20));
  });
 });


### PR DESCRIPTION
# Description

Replace console logging with assertions to ensure future updates do not cause regressions.

# Additional Notes

I removed the counters because they did not provide value for this particular issue. Subsequent issues/tests will reintroduce the concept of counters to ensure fetch is called efficiently.