### PR TITLE
Add `relatorDataCache` in serialize method to avoid duplicate lookups during `recurseRelators` call

### DIFF
--- a/.changeset/khaki-lizards-roll.md
+++ b/.changeset/khaki-lizards-roll.md
@@ -1,0 +1,5 @@
+---
+"ts-japi": minor
+---
+
+Add `relatorDataCache` in serialize method to avoid duplicate lookups during `recurseRelators` call

--- a/src/classes/relator.ts
+++ b/src/classes/relator.ts
@@ -7,6 +7,7 @@ import ResourceIdentifier from "../models/resource-identifier.model";
 import Resource from "../models/resource.model";
 import { Dictionary, nullish } from "../types/global.types";
 import merge from "../utils/merge";
+import { Helpers } from "../utils/serializer.utils";
 import Serializer from "./serializer";
 
 /**
@@ -68,7 +69,9 @@ export default class Relator<PrimaryType, RelatedType extends Dictionary<any> = 
  /** @internal Creates related resources */
  public getRelatedResource: (
   data: RelatedType,
-  options?: SerializerOptions<RelatedType>
+  options?: SerializerOptions<RelatedType>,
+  helpers?: Helpers<RelatedType>,
+  relatorDataCache?: Map<Relator<any>, Dictionary<any>[]>
  ) => Promise<Resource<RelatedType>>;
 
  /** @internal Gets related links from primary data and related data */
@@ -93,12 +96,15 @@ export default class Relator<PrimaryType, RelatedType extends Dictionary<any> = 
  }
 
  /** @internal Creates a {@linkcode Relationship}. */
- public async getRelationship(data: PrimaryType) {
+ public async getRelationship(data: PrimaryType, relatedDataCache?: Dictionary<any>[]) {
   // Initialize options.
   const relationshipOptions: RelationshipOptions = {};
 
   // Get related data.
   const relatedData = await this.getRelatedData(data);
+  if (relatedData && relatedDataCache) {
+   relatedDataCache.push(...(Array.isArray(relatedData) ? relatedData : [relatedData]));
+  }
 
   // Get related links.
   const links = this.getRelatedLinks(data, relatedData);

--- a/test/issue-24.test.ts
+++ b/test/issue-24.test.ts
@@ -17,6 +17,6 @@ it("Should bypass recurse cycles after data fetched", async () => {
 
  await SerializerA.serialize([{ id: "1", prop: "a1" }, { id: "1", prop: "a2" }], { depth: 20 });
 
- // The result is 4 because to relator is called each time.
- expect(fetchCounter).toBe(4);
+ // The result is 2 because to relator is called each time.
+ expect(fetchCounter).toBe(2);
 });

--- a/test/relator.test.ts
+++ b/test/relator.test.ts
@@ -149,4 +149,32 @@ describe("Relator Tests", () => {
    );
   });
  });
+ describe("Cache Tests", () => {
+  it.each(sliceRandom(Article.storage, NUMBER_OF_TESTS).map((article) => article.id))(
+   "Should cache fetched data for Article ID %s",
+   async (articleId) => {
+    const article = Article.find(articleId);
+
+    // test when fetch returns multiple elements
+    const commentsCache = [];
+    const ArticleCommentsRelator = new Relator(
+     async (article: Article) => article.getComments(),
+     CommentSerializer
+    );
+
+    await ArticleCommentsRelator.getRelationship(article, commentsCache);
+    expect(commentsCache).toHaveLength(article.getComments().length);
+
+    // test when fetch returns a single element
+    const authorCache = [];
+    const ArticleAuthorRelator = new Relator(
+     async (article: Article) => article.getAuthor(),
+     UserSerializer
+    );
+
+    await ArticleAuthorRelator.getRelationship(article, authorCache);
+    expect(authorCache).toHaveLength(1);
+   }
+  );
+ });
 });


### PR DESCRIPTION
# Description

Fixes #24 

# Notes

All of the tests are passing, but this was more or less a full rewrite of the `recurseRelators` internals. A thorough set of eyes would be greatly appreciated 🙏