### PR TITLE
fix: remove explicit import from "url"

### DIFF
--- a/src/models/link.model.ts
+++ b/src/models/link.model.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import Meta from './meta.model';
 
 export default class Link {


### PR DESCRIPTION
It makes ts-japi compatible with edge runtimes like Cloudflare where importing from built-in node modules is not supported.