### PR TITLE
get the serializers 'idKey' field as the cache key

### DIFF
--- a/src/classes/serializer.ts
+++ b/src/classes/serializer.ts
@@ -81,6 +81,13 @@ export default class Serializer<PrimaryType extends Dictionary<any> = any> {
   }
 
   /**
+   * Gets the idKey (ie. name of the id field for the given model)
+   */
+  public getIdKeyFieldName() {
+    return this.options.idKey;
+  }
+
+  /**
    * Gets the {@link Relator}s associated with this serializer
    */
   public getRelators() {

--- a/src/utils/serializer.utils.ts
+++ b/src/utils/serializer.utils.ts
@@ -115,7 +115,9 @@ export async function recurseRelators(
         // - includeFields !== undefined
         // - includeFields has entry where field = relatedName
         if (!includeFields || includeFields.map((i) => i.field).includes(relator.relatedName)) {
-          const key = `${relator.serializer.collectionName}:${cache[i].id as string}`;
+          const key = `${relator.serializer.collectionName}:${
+            cache[i][relator.serializer.getIdKeyFieldName()] as string
+          }`;
           if (!keys.includes(key)) {
             // const key = resource.getKey();
             const resource = await relator.getRelatedResource(


### PR DESCRIPTION
instead of hardcoding `id` as the field name

fixes #104