### PR TITLE
fix: auto-exclude relator fields from attributes

### DIFF
--- a/src/utils/serializer.utils.ts
+++ b/src/utils/serializer.utils.ts
@@ -200,9 +200,17 @@ export class Helpers<PrimaryType extends Dictionary<any> = any> {
     if (options.projection === undefined) {
       this.projectAttributes = () => undefined;
     } else if (options.projection === null) {
+      const relatorKeys = this.relators
+        ? new Set(Object.keys(this.relators))
+        : undefined;
       this.projectAttributes = (data: PrimaryType) => {
         const attributes = { ...data };
         delete attributes[options.idKey];
+        if (relatorKeys) {
+          for (const key of relatorKeys) {
+            delete attributes[key as keyof PrimaryType];
+          }
+        }
         return attributes;
       };
     } else {

--- a/test/issue-77.test.ts
+++ b/test/issue-77.test.ts
@@ -1,0 +1,41 @@
+import { Relator, Serializer } from "../lib";
+
+describe("Issue #77 - Related fields should not appear in attributes", () => {
+  interface Article {
+    id: string;
+    title: string;
+  }
+
+  interface User {
+    articles: Article[];
+    id: string;
+    name: string;
+  }
+
+  const ArticleSerializer = new Serializer<Article>("Article");
+  const UserArticleRelator = new Relator<User, Article>(
+    async (user) => user.articles,
+    ArticleSerializer
+  );
+  const UserSerializer = new Serializer<User>("User", {
+    relators: [UserArticleRelator],
+  });
+
+  it("should exclude relator fields from attributes by default", async () => {
+    const user: User = {
+      id: "1",
+      name: "Foo",
+      articles: [
+        { id: "1", title: "Article 1" },
+        { id: "2", title: "Article 2" },
+      ],
+    };
+
+    const document = await UserSerializer.serialize(user);
+    const data = document.data as any;
+
+    expect(data.attributes).not.toHaveProperty("Article");
+    expect(data.attributes).toHaveProperty("name", "Foo");
+    expect(data.relationships).toHaveProperty("Article");
+  });
+});

--- a/test/serializer.test.ts
+++ b/test/serializer.test.ts
@@ -273,7 +273,6 @@ describe("Serializer Tests", () => {
         id: user.id,
         attributes: {
           createdAt: user.createdAt.toISOString(),
-          articles: user.articles,
           comments: user.comments,
         },
         relationships: {
@@ -302,7 +301,6 @@ describe("Serializer Tests", () => {
           id: user.id,
           attributes: {
             createdAt: user.createdAt.toISOString(),
-            articles: user.articles,
             comments: user.comments,
           },
           relationships: {


### PR DESCRIPTION
## Summary

When a `Relator` is defined for a field, that field is now automatically excluded from serialized `attributes` under the default `projection: null`. Previously the field appeared in both `attributes` and `relationships`, which is incorrect per the JSON:API spec. Users had to explicitly set a projection to work around this.

## Test plan

- [x] All 105 existing tests pass
- [x] New regression test added (`test/issue-77.test.ts`)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)